### PR TITLE
Fixed error on Interface Example

### DIFF
--- a/intDemoInterface.al
+++ b/intDemoInterface.al
@@ -19,8 +19,10 @@ pageextension 50105 ItemListCustom extends "Item List"
     trigger OnOpenPage()
     var 
       intInterface: Interface TestInt;     //Interface - new object !!   
+      cduCodeunit: Codeunit Test;          //Codeunit - implementing new Interface
     
     begin
+        intInterface := cduCodeunit;  // We tell the interface to use the cduCodeunit implementation of our functions.
         locPrintHallo(intInterface);
     end;
 


### PR DESCRIPTION
The way the Interface Example was structured, there was no printing of the Text.
In order to correctly print "Hallo" we need to tell the interface which implementation to use (in our case "cduCodeunit").